### PR TITLE
feat: add version parameter to treasure solver endpoints

### DIFF
--- a/Server/Features/TreasureSolver/Controllers/CluesController.cs
+++ b/Server/Features/TreasureSolver/Controllers/CluesController.cs
@@ -20,22 +20,36 @@ public class CluesController : ControllerBase
     ///     Find clues in map
     /// </summary>
     [HttpGet("at-map/{mapId:long}")]
-    public async Task<IReadOnlyCollection<Clue>> FindCluesInMap([FromServices] FindCluesService findCluesService, long mapId) => await findCluesService.FindCluesInMapAsync(mapId);
+    public async Task<IReadOnlyCollection<Clue>> FindCluesInMap(
+        [FromServices] FindCluesService findCluesService,
+        long mapId,
+        string version = "latest",
+        CancellationToken cancellationToken = default
+    ) =>
+        // FIXME: clues are not versioned right now so the version parameter is always ignored by this endpoint
+        await findCluesService.FindCluesInMapAsync(mapId, cancellationToken);
 
     /// <summary>
     ///     Find clues at position
     /// </summary>
     [HttpGet("at-position/{posX:int}/{posY:int}")]
-    public async Task<IReadOnlyCollection<Clue>> FindCluesAtPosition([FromServices] FindCluesService findCluesService, int posX, int posY) =>
-        await findCluesService.FindCluesAtPositionAsync(posX, posY);
+    public async Task<IReadOnlyCollection<Clue>> FindCluesAtPosition(
+        [FromServices] FindCluesService findCluesService,
+        int posX,
+        int posY,
+        string version = "latest",
+        CancellationToken cancellationToken = default
+    ) =>
+        await findCluesService.FindCluesAtPositionAsync(posX, posY, version, cancellationToken);
 
     /// <summary>
     ///     Export clues
     /// </summary>
     [HttpGet("export")]
-    public async Task<FileStreamResult> ExportClues([FromServices] ExportCluesService exportCluesService)
+    public async Task<FileStreamResult> ExportClues([FromServices] ExportCluesService exportCluesService, string version = "latest", CancellationToken cancellationToken = default)
     {
-        ExportCluesService.File file = await exportCluesService.ExportCluesAsync();
+        // FIXME: clues are not versioned right now so the version parameter is always ignored by this endpoint
+        ExportCluesService.File file = await exportCluesService.ExportCluesAsync(cancellationToken);
         return new FileStreamResult(file.Content, file.Type) { FileDownloadName = file.Name };
     }
 
@@ -44,9 +58,16 @@ public class CluesController : ControllerBase
     /// </summary>
     [HttpPost]
     [Authorize]
-    public async Task RegisterClues([FromServices] RegisterCluesService registerCluesService, [FromServices] ApplicationDbContext dbContext, RegisterCluesRequest request)
+    public async Task RegisterClues(
+        [FromServices] RegisterCluesService registerCluesService,
+        [FromServices] ApplicationDbContext dbContext,
+        RegisterCluesRequest request,
+        string version = "latest",
+        CancellationToken cancellationToken = default
+    )
     {
+        // FIXME: clues are not versioned right now so the version parameter is always ignored by this endpoint
         PrincipalEntity principal = await ControllerContext.RequirePrincipal(dbContext);
-        await registerCluesService.RegisterCluesAsync(principal, request);
+        await registerCluesService.RegisterCluesAsync(principal, request, cancellationToken);
     }
 }

--- a/Server/Features/TreasureSolver/Controllers/TreasureSolverController.cs
+++ b/Server/Features/TreasureSolver/Controllers/TreasureSolverController.cs
@@ -90,7 +90,7 @@ public class TreasureSolverController : ControllerBase
 
         foreach (RawWorldGraphNode node in nodes)
         {
-            FindNextNodeContainingClueResult result = await _solver.FindNextNodeContainingClueAsync(node.Id, request.Direction, request.ClueId, cancellationToken);
+            FindNextNodeContainingClueResult result = await _solver.FindNextNodeContainingClueAsync(node.Id, request.Direction, request.ClueId, version, cancellationToken);
             if (result.Found)
             {
                 return new FindNextMapResponse { Found = true, Map = result.Map, Distance = result.Distance };

--- a/Server/Features/TreasureSolver/Controllers/TreasureSolverController.cs
+++ b/Server/Features/TreasureSolver/Controllers/TreasureSolverController.cs
@@ -55,14 +55,14 @@ public class TreasureSolverController : ControllerBase
     ///     The endpoint is mostly used to understand how <see cref="FindNodeRequest" />s work. The actual clue search is performed by <see cref="FindNextClue" />.
     /// </remarks>
     [HttpPost("find-nodes")]
-    public async Task<IEnumerable<MapNodeWithPosition>> FindNodes(FindNodeRequest request, CancellationToken cancellationToken = default)
+    public async Task<IEnumerable<MapNodeWithPosition>> FindNodes(FindNodeRequest request, string version = "latest", CancellationToken cancellationToken = default)
     {
-        RawWorldGraphService rawWorldGraphService = await _rawWorldGraphServiceFactory.CreateServiceAsync(cancellationToken: cancellationToken);
-        RawMapsService rawMapsService = await _rawMapsServiceFactory.CreateServiceAsync(cancellationToken: cancellationToken);
-        RawMapPositionsService rawMapPositionsService = await _rawMapPositionsServiceFactory.CreateServiceAsync(cancellationToken: cancellationToken);
+        RawWorldGraphService rawWorldGraphService = await _rawWorldGraphServiceFactory.CreateServiceAsync(version, cancellationToken);
+        RawMapsService rawMapsService = await _rawMapsServiceFactory.CreateServiceAsync(version, cancellationToken);
+        RawMapPositionsService rawMapPositionsService = await _rawMapPositionsServiceFactory.CreateServiceAsync(version, cancellationToken);
         IWorldDataProvider worldData = WorldDataBuilder.FromRawServices(rawWorldGraphService, rawMapsService, rawMapPositionsService).Build();
 
-        MapsService mapsService = await _worldServicesFactory.CreateMapsServiceAsync(cancellationToken: cancellationToken);
+        MapsService mapsService = await _worldServicesFactory.CreateMapsServiceAsync(version, cancellationToken);
 
         NodeFinder nodeFinder = new(worldData);
 
@@ -73,11 +73,11 @@ public class TreasureSolverController : ControllerBase
     ///     Find next clue
     /// </summary>
     [HttpPost("find-next-clue")]
-    public async Task<ActionResult<FindNextMapResponse>> FindNextClue(FindNextClueRequest request, CancellationToken cancellationToken)
+    public async Task<ActionResult<FindNextMapResponse>> FindNextClue(FindNextClueRequest request, string version = "latest", CancellationToken cancellationToken = default)
     {
-        RawWorldGraphService rawWorldGraphService = await _rawWorldGraphServiceFactory.CreateServiceAsync(cancellationToken: cancellationToken);
-        RawMapsService rawMapsService = await _rawMapsServiceFactory.CreateServiceAsync(cancellationToken: cancellationToken);
-        RawMapPositionsService rawMapPositionsService = await _rawMapPositionsServiceFactory.CreateServiceAsync(cancellationToken: cancellationToken);
+        RawWorldGraphService rawWorldGraphService = await _rawWorldGraphServiceFactory.CreateServiceAsync(version, cancellationToken);
+        RawMapsService rawMapsService = await _rawMapsServiceFactory.CreateServiceAsync(version, cancellationToken);
+        RawMapPositionsService rawMapPositionsService = await _rawMapPositionsServiceFactory.CreateServiceAsync(version, cancellationToken);
         IWorldDataProvider worldData = WorldDataBuilder.FromRawServices(rawWorldGraphService, rawMapsService, rawMapPositionsService).Build();
 
         NodeFinder nodeFinder = new(worldData);

--- a/Server/Features/TreasureSolver/Services/Clues/DataSources/IClueRecordsSource.cs
+++ b/Server/Features/TreasureSolver/Services/Clues/DataSources/IClueRecordsSource.cs
@@ -10,15 +10,15 @@ public interface IClueRecordsSource
     /// <summary>
     ///     Get the last modification date of the data in the source.
     /// </summary>
-    public Task<DateTime?> GetLastModificationDate();
+    public Task<DateTime?> GetLastModificationDate(CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Get the clues in the given map.
     /// </summary>
-    public Task<IReadOnlyCollection<ClueRecord>> GetCluesInMap(long mapId);
+    public Task<IReadOnlyCollection<ClueRecord>> GetCluesInMap(long mapId, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Build a dictionary containing all the clue records in the source.
     /// </summary>
-    Task<IReadOnlyDictionary<long, IReadOnlyCollection<ClueRecord>>> ExportData();
+    Task<IReadOnlyDictionary<long, IReadOnlyCollection<ClueRecord>>> ExportData(CancellationToken cancellationToken = default);
 }

--- a/Server/Features/TreasureSolver/Services/Clues/DataSources/StaticClueRecordsSource.cs
+++ b/Server/Features/TreasureSolver/Services/Clues/DataSources/StaticClueRecordsSource.cs
@@ -13,7 +13,7 @@ class StaticClueRecordsSource : IClueRecordsSource
     public DateTime? LastModificationDate { get; }
     public IReadOnlyDictionary<long, IReadOnlyCollection<ClueRecord>> Clues { get; }
 
-    public Task<DateTime?> GetLastModificationDate() => Task.FromResult(LastModificationDate);
-    public Task<IReadOnlyCollection<ClueRecord>> GetCluesInMap(long mapId) => Task.FromResult(Clues.GetValueOrDefault(mapId) ?? []);
-    public Task<IReadOnlyDictionary<long, IReadOnlyCollection<ClueRecord>>> ExportData() => Task.FromResult(Clues);
+    public Task<DateTime?> GetLastModificationDate(CancellationToken cancellationToken = default) => Task.FromResult(LastModificationDate);
+    public Task<IReadOnlyCollection<ClueRecord>> GetCluesInMap(long mapId, CancellationToken cancellationToken = default) => Task.FromResult(Clues.GetValueOrDefault(mapId) ?? []);
+    public Task<IReadOnlyDictionary<long, IReadOnlyCollection<ClueRecord>>> ExportData(CancellationToken cancellationToken = default) => Task.FromResult(Clues);
 }

--- a/Server/Features/TreasureSolver/Services/Clues/ExportCluesService.cs
+++ b/Server/Features/TreasureSolver/Services/Clues/ExportCluesService.cs
@@ -56,10 +56,10 @@ public class ExportCluesService
     /// <summary>
     ///     Export clues
     /// </summary>
-    public async Task<File> ExportCluesAsync()
+    public async Task<File> ExportCluesAsync(CancellationToken cancellationToken = default)
     {
         string version = Metadata.Version?.ToString() ?? "~dev";
-        DateTime lastModificationDate = await _findCluesService.GetLastModificationDateAsync() ?? DateTime.Now;
+        DateTime lastModificationDate = await _findCluesService.GetLastModificationDateAsync(cancellationToken) ?? DateTime.Now;
 
         string filepath = GetExportedFilePath();
         string filename = GetExportedFileName(version, lastModificationDate);
@@ -87,7 +87,7 @@ public class ExportCluesService
             }
 
             await using FileStream writeStream = System.IO.File.Open(path, FileMode.Create);
-            await JsonSerializer.SerializeAsync(writeStream, content, _serializerOptions);
+            await JsonSerializer.SerializeAsync(writeStream, content, _serializerOptions, cancellationToken);
 
             _logger.LogInformation("Saved export result at {Path}.", path);
         }

--- a/Server/Features/TreasureSolver/Services/Clues/FindCluesService.cs
+++ b/Server/Features/TreasureSolver/Services/Clues/FindCluesService.cs
@@ -38,9 +38,9 @@ public class FindCluesService
     /// <summary>
     ///     Get the last modification date of all the data used by the service.
     /// </summary>
-    public async Task<DateTime?> GetLastModificationDateAsync()
+    public async Task<DateTime?> GetLastModificationDateAsync(CancellationToken cancellationToken = default)
     {
-        DateTime?[] dates = await Task.WhenAll(GetDataSources().Select(s => s.GetLastModificationDate()));
+        DateTime?[] dates = await Task.WhenAll(GetDataSources().Select(s => s.GetLastModificationDate(cancellationToken)));
         return dates.Max();
     }
 
@@ -51,44 +51,44 @@ public class FindCluesService
     ///     Different data sources might contradict, for example a principal might have registered a record saying that a given clue is not found in a given map.
     ///     For now, we resolve contradictions by taking the information that has the most recent modification date.
     /// </remarks>
-    public async Task<IReadOnlyCollection<Clue>> FindCluesInMapAsync(long mapId)
+    public async Task<IReadOnlyCollection<Clue>> FindCluesInMapAsync(long mapId, CancellationToken cancellationToken = default)
     {
         List<ClueRecord> results = [];
         foreach (IClueRecordsSource source in GetDataSources())
         {
-            IReadOnlyCollection<ClueRecord> cluesInMap = await source.GetCluesInMap(mapId);
+            IReadOnlyCollection<ClueRecord> cluesInMap = await source.GetCluesInMap(mapId, cancellationToken);
             results.AddRange(cluesInMap);
         }
 
-        return await GetCluesFromRecordsAsync(results);
+        return await GetCluesFromRecordsAsync(results, cancellationToken);
     }
 
     /// <summary>
     ///     Get all the clues in maps at the given coordinates from all the data sources.
     /// </summary>
     /// <inheritdoc cref="FindCluesInMapAsync" />
-    public async Task<IReadOnlyCollection<Clue>> FindCluesAtPositionAsync(int posX, int posY)
+    public async Task<IReadOnlyCollection<Clue>> FindCluesAtPositionAsync(int posX, int posY, string version = "latest", CancellationToken cancellationToken = default)
     {
-        RawMapPositionsService rawMapPositionsService = await _rawMapPositionsServiceFactory.CreateServiceAsync();
+        RawMapPositionsService rawMapPositionsService = await _rawMapPositionsServiceFactory.CreateServiceAsync(version, cancellationToken);
         long[] mapIds = rawMapPositionsService.GetMapPositions().Where(m => m.PosX == posX && m.PosY == posY).Select(m => m.MapId).ToArray();
 
         List<ClueRecord> results = [];
         foreach (long mapId in mapIds)
         foreach (IClueRecordsSource source in GetDataSources())
         {
-            IReadOnlyCollection<ClueRecord> cluesInMap = await source.GetCluesInMap(mapId);
+            IReadOnlyCollection<ClueRecord> cluesInMap = await source.GetCluesInMap(mapId, cancellationToken);
             results.AddRange(cluesInMap);
         }
 
-        return await GetCluesFromRecordsAsync(results);
+        return await GetCluesFromRecordsAsync(results, cancellationToken);
     }
 
-    async Task<IReadOnlyCollection<Clue>> GetCluesFromRecordsAsync(IEnumerable<ClueRecord> results)
+    async Task<IReadOnlyCollection<Clue>> GetCluesFromRecordsAsync(IEnumerable<ClueRecord> results, CancellationToken cancellationToken = default)
     {
         // TODO: maybe implement smarter conflict resolution, e.g. each data source can vote for their choice.
 
-        LanguagesService languagesService = await _languagesServiceFactory.CreateLanguagesServiceAsync();
-        RawPointOfInterestsService rawPointOfInterestsService = await _rawPointOfInterestsServiceFactory.CreateServiceAsync();
+        LanguagesService languagesService = await _languagesServiceFactory.CreateLanguagesServiceAsync(cancellationToken: cancellationToken);
+        RawPointOfInterestsService rawPointOfInterestsService = await _rawPointOfInterestsServiceFactory.CreateServiceAsync(cancellationToken: cancellationToken);
         ClueRecord[] records = results.GroupBy(r => r.ClueId).Select(g => g.OrderByDescending(r => r.RecordDate).First()).Where(r => r.Found).ToArray();
         return records.Select(
                 r =>

--- a/Server/Features/TreasureSolver/Services/Clues/RegisterCluesService.cs
+++ b/Server/Features/TreasureSolver/Services/Clues/RegisterCluesService.cs
@@ -23,14 +23,16 @@ public class RegisterCluesService
     /// <summary>
     ///     Register that the <c>author</c> has found (or not found) the clues in <c>request</c>.
     /// </summary>
-    public async Task RegisterCluesAsync(PrincipalEntity author, RegisterCluesRequest request)
+    public async Task RegisterCluesAsync(PrincipalEntity author, RegisterCluesRequest request, CancellationToken cancellationToken = default)
     {
         foreach (RegisterClueRequest clueRequest in request.Clues)
         {
             ClueAtMapStatus status = clueRequest.Found ? ClueAtMapStatus.Found : ClueAtMapStatus.NotFound;
 
-            ClueRecordEntity? existingClue =
-                await _context.ClueRecords.SingleOrDefaultAsync(c => c.MapId == clueRequest.MapId && c.ClueId == clueRequest.ClueId && c.Author == author);
+            ClueRecordEntity? existingClue = await _context.ClueRecords.SingleOrDefaultAsync(
+                c => c.MapId == clueRequest.MapId && c.ClueId == clueRequest.ClueId && c.Author == author,
+                cancellationToken
+            );
             if (existingClue != null)
             {
                 existingClue.UpdateStatus(status);
@@ -38,9 +40,9 @@ public class RegisterCluesService
             }
 
             ClueRecordEntity newClue = new(clueRequest.ClueId, clueRequest.MapId, author, status);
-            await _context.AddAsync(newClue);
+            await _context.AddAsync(newClue, cancellationToken);
         }
 
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(cancellationToken);
     }
 }

--- a/Server/Features/TreasureSolver/Services/TreasureSolverService.cs
+++ b/Server/Features/TreasureSolver/Services/TreasureSolverService.cs
@@ -33,12 +33,13 @@ public class TreasureSolverService(
         long startNodeId,
         Direction direction,
         int clueId,
+        string version = "latest",
         CancellationToken cancellationToken = default
     )
     {
-        RawWorldGraphService rawWorldGraphService = await rawWorldGraphServiceFactory.CreateServiceAsync(cancellationToken: cancellationToken);
-        RawMapsService rawMapsService = await rawMapsServiceFactory.CreateServiceAsync(cancellationToken: cancellationToken);
-        RawMapPositionsService rawMapPositionsService = await rawMapPositionsServiceFactory.CreateServiceAsync(cancellationToken: cancellationToken);
+        RawWorldGraphService rawWorldGraphService = await rawWorldGraphServiceFactory.CreateServiceAsync(version, cancellationToken);
+        RawMapsService rawMapsService = await rawMapsServiceFactory.CreateServiceAsync(version, cancellationToken);
+        RawMapPositionsService rawMapPositionsService = await rawMapPositionsServiceFactory.CreateServiceAsync(version, cancellationToken);
 
         RawWorldGraphNode? startNode = rawWorldGraphService.GetNode(startNodeId);
         if (startNode == null)
@@ -52,7 +53,7 @@ public class TreasureSolverService(
         int distance = 1;
         foreach (MapNodeWithPosition node in pathFinder.EnumerateNodesInDirection(startNode, direction))
         {
-            IReadOnlyCollection<Clue> clues = await findCluesService.FindCluesInMapAsync(node.MapId);
+            IReadOnlyCollection<Clue> clues = await findCluesService.FindCluesInMapAsync(node.MapId, cancellationToken);
             if (clues.Any(c => c.ClueId == clueId))
             {
                 return new FindNextNodeContainingClueResult(true, node, distance);

--- a/Server/Infrastructure/Authentication/ControllerExtensions.cs
+++ b/Server/Infrastructure/Authentication/ControllerExtensions.cs
@@ -7,7 +7,7 @@ namespace DBI.Server.Infrastructure.Authentication;
 
 static class ControllerExtensions
 {
-    public static async Task<PrincipalEntity?> GetPrincipal(this ControllerContext context, ApplicationDbContext dbContext)
+    public static async Task<PrincipalEntity?> GetPrincipal(this ControllerContext context, ApplicationDbContext dbContext, CancellationToken cancellationToken = default)
     {
         if (context.HttpContext.User.Identity?.IsAuthenticated != true)
         {
@@ -20,9 +20,9 @@ static class ControllerExtensions
             return null;
         }
 
-        return await dbContext.Principals.FindAsync(principalId);
+        return await dbContext.Principals.FindAsync([principalId], cancellationToken);
     }
 
-    public static async Task<PrincipalEntity> RequirePrincipal(this ControllerContext context, ApplicationDbContext dbContext) =>
-        await GetPrincipal(context, dbContext) ?? throw new InvalidOperationException("Could not determine current principal.");
+    public static async Task<PrincipalEntity> RequirePrincipal(this ControllerContext context, ApplicationDbContext dbContext, CancellationToken cancellationToken = default) =>
+        await GetPrincipal(context, dbContext, cancellationToken) ?? throw new InvalidOperationException("Could not determine current principal.");
 }


### PR DESCRIPTION
allow to specify the version of game data to use when calling Treasure Solver endpoints

This PR allows to select a specific version to use, e.g. 3.0.2.4 that contains world graph data. By default the latest version of game data is used but it is not guaranteed to contain the world graph.
This is a quick workaround to allow the use of the treasure solver API even though the extraction of world graph data by DDC is not working properly.

Future improvement: make it so "latest" fetches the latest version that contains the world-graph instead of the latest version that has been published.

closes #76